### PR TITLE
CRUD items with minimalist flux

### DIFF
--- a/scripts/auth.js
+++ b/scripts/auth.js
@@ -1,0 +1,24 @@
+import btoa from "btoa";
+
+
+export default class Auth {
+  constructor(events, location) {
+    this.events = events;
+    this.location = location;
+    this.server = '';
+  }
+
+  configure(config) {
+    this.server = config.server;
+  }
+
+  authenticate() {
+    // Take username from location hash (With default value):
+    const user = this.location.hash = (this.location.hash.slice(1) || "public-demo");
+    const userpass64 = btoa(user + ":s3cr3t");
+    const headers = {Authorization: "Basic " + userpass64};
+    const server = this.server;
+
+    this.events.emit('auth:login', {user, headers, server});
+  }
+}

--- a/scripts/components/App.js
+++ b/scripts/components/App.js
@@ -1,36 +1,98 @@
-import React from "react";
+import React, { PropTypes } from "react";
 
 
 export class Form extends React.Component {
+  static contextTypes = {
+    controller: PropTypes.object.isRequired
+  };
+
+  constructor(props) {
+    super(props);
+    this.state = {record: this.props.record || {}};
+  }
 
   onFormSubmit(event) {
     event.preventDefault();
-    var record = {label: event.target.elements.label.value};
-    this.props.updateRecord(record);
+    const action = this.props.record ? 'update' : 'create';
+    this.context.controller.dispatch(`action:${action}`, this.state.record);
+  }
+
+  onChange(field, event) {
+    const newrecord = Object.assign({}, this.state.record, {[field]: event.target.value});
+    this.setState({record: newrecord});
   }
 
   render() {
     return (
       <form onSubmit={this.onFormSubmit.bind(this)}>
-        <input name="label" type="text" />
-        <button type="submit">Add</button>
+        <input autofocus name="label" type="text"
+               placeholder="Label"
+               value={this.state.record.label}
+               onChange={this.onChange.bind(this, "label")} />
+        <button type="submit">{this.props.record ? "Save" : "Add"}</button>
       </form>
     );
   }
 }
 
 
-export class List extends React.Component {
+export class Item extends React.Component {
+  static contextTypes = {
+    controller: PropTypes.object.isRequired
+  };
 
-  static get defaultProps() {
-    return {items: []};
+  onItemClick() {
+    this.context.controller.dispatch('action:edit', this.props.index)
+  }
+
+  onDeleteClick() {
+    this.context.controller.dispatch('action:delete', this.props.item);
+  }
+
+  render() {
+    if (!this.props.editing) {
+      return (
+        <li key={this.props.index} className={this.props.item._status}
+            onClick={this.onItemClick.bind(this)}>{this.props.item.label}</li>
+      );
+    }
+    return (
+      <li key={this.props.index}>
+        <Form record={this.props.item}/>
+        <button onClick={this.onDeleteClick.bind(this)}>Delete</button>
+      </li>
+    );
+  }
+}
+
+
+export class List extends React.Component {
+  static contextTypes = {
+    controller: PropTypes.object.isRequired
+  };
+
+  constructor(props, context) {
+    super(props, context);
+    this.state = {current: null};
+  }
+
+  componentDidMount() {
+    this.context.controller.on("action:edit", (index) => {
+      this.setState({current: index});
+    });
+    this.context.controller.on("action:update, action:delete", () => {
+      this.setState({current: null});
+    });
   }
 
   render() {
     return (
       <ul>{
-        this.props.items.map((label, i) => {
-          return <li key={i}>{label}</li>;
+        this.props.items.map((item, i) => {
+          return <Item key={i}
+                       index={i}
+                       item={item}
+                       editing={i === this.state.current}/>;
         })
       }</ul>
     );
@@ -38,37 +100,81 @@ export class List extends React.Component {
 }
 
 
-export default class App extends React.Component {
+export class Preferences extends React.Component {
+  static contextTypes = {
+    controller: PropTypes.object.isRequired
+  };
 
-  constructor(props) {
-    super(props);
-    this.state = this.props.store.state;
-    this.props.store.on("change", state => {
-      this.setState(Object.assign({busy: false}, state));
-    });
-    this.props.store.on("error", error => {
-      this.setState({busy: false, error: error.message});
-    });
-    this.props.store.load();
-  }
-
-  updateRecord(record) {
-    this.props.store.create(record);
-  }
-
-  syncRecords() {
-    this.setState({busy: true, error: ""});
-    this.props.store.sync();
+  onChange(event) {
+    const config = {server: event.target.value};
+    this.context.controller.dispatch("action:configure", config);
   }
 
   render() {
-    var disabled = this.state.busy ? "disabled" : "";
+    return (
+      <div className="preferences">
+        <input id="toggle" type="checkbox"></input>
+        <label htmlFor="toggle">Preferences</label>
+        <form>
+          <label>Server
+            <input value={this.props.server}
+                   onChange={this.onChange.bind(this)}/>
+          </label>
+        </form>
+      </div>
+    );
+  }
+}
+
+
+export default class App extends React.Component {
+  static childContextTypes = {
+    controller: PropTypes.object
+  };
+
+  constructor(props) {
+    super(props);
+    this.state = {busy: false, error: "", items: []};
+  }
+
+  getChildContext() {
+    // Pass the controller to child components.
+    return {
+      controller: this.props.controller
+    };
+  }
+
+  componentDidMount() {
+    this.props.controller.on("store:busy", state => {
+      this.setState({busy: state, error: ""});
+    });
+    this.props.controller.on("store:change", state => {
+      this.setState({items: state.items});
+    });
+    this.props.controller.on("store:error", error => {
+      this.setState({error: error.message});
+    });
+    this.props.controller.on("config:change", config => {
+      this.setState({server: config.server});
+    });
+
+    // Start the application!
+    this.props.controller.dispatch('action:start');
+  }
+
+  onSyncClick() {
+    this.props.controller.dispatch('action:sync');
+  }
+
+  render() {
+    const disabled = this.state.busy ? "disabled" : "";
     return (
       <div className={disabled}>
-        <Form updateRecord={this.updateRecord.bind(this)}/>
-        <List items={this.state.items.map(item => item.label)}/>
-        <button onClick={this.syncRecords.bind(this)} disabled={disabled}>Sync!</button>
         <div className="error">{this.state.error}</div>
+        <Form />
+        <List items={this.state.items}/>
+        <button onClick={this.onSyncClick.bind(this)} disabled={disabled}>Sync!</button>
+        <Preferences server={this.state.server} />
       </div>
     );
   }

--- a/scripts/controller.js
+++ b/scripts/controller.js
@@ -1,0 +1,65 @@
+const DEFAULT_SERVER = "https://kinto.dev.mozaws.net/v1";
+
+
+export default class Controller {
+
+  constructor(components, events) {
+    this.store = components.store;
+    this.auth = components.auth;
+    this.events = events;
+
+    this.events.on('auth:login', this.onLogin.bind(this));
+    this.events.on('action:start', this.onStart.bind(this));
+    this.events.on('action:configure', this.onConfigure.bind(this));
+    this.events.on('action:create', this.onCreate.bind(this));
+    this.events.on('action:update', this.onUpdate.bind(this));
+    this.events.on('action:delete', this.onDelete.bind(this));
+    this.events.on('action:sync', this.onSync.bind(this));
+  }
+
+  on(events, callback) {
+    const names = events.split(/\s*,\s*/);
+    names.forEach(event => this.events.on(event, callback));
+  }
+
+  dispatch(name, data) {
+    this.events.emit(name, data);
+  }
+
+  onStart() {
+    // Start application with default config.
+    const previous = window.localStorage.getItem("config");
+    const config = previous ? JSON.parse(previous) : {server: DEFAULT_SERVER};
+    this.dispatch('action:configure', config);
+  }
+
+  onConfigure(config) {
+    // Save config for next sessions.
+    window.localStorage.setItem("config", JSON.stringify(config));
+    this.events.emit("config:change", config);
+
+    this.auth.configure(config);
+    this.auth.authenticate();
+  }
+
+  onLogin(info) {
+    this.store.configure(info);
+    this.store.load();
+  }
+
+  onCreate(record) {
+    this.store.create(record);
+  }
+
+  onUpdate(record) {
+    this.store.update(record);
+  }
+
+  onDelete(record) {
+    this.store.delete(record);
+  }
+
+  onSync() {
+    this.store.sync();
+  }
+}

--- a/scripts/index.js
+++ b/scripts/index.js
@@ -1,25 +1,16 @@
 import "babel/polyfill";
-import btoa from "btoa";
+import { EventEmitter } from "events";
 import React from "react";
+
 import App from "./components/App";
-import { Store } from "./store";
-import Kinto from "kinto";
-
-// Take username from location hash (With default value):
-const user = window.location.hash = (window.location.hash.slice(1) || "public-demo");
-const userpass64 = btoa(user + ":s3cr3t");
-
-// Use Mozilla demo server with Basic authentication:
-const server = "https://kinto.dev.mozaws.net/v1";
-const kinto = new Kinto({
-  remote: server,
-  // Make sure local data depend on current user.
-  dbPrefix: user,
-  // Provide authentication header.
-  headers: {Authorization: "Basic " + userpass64}
-});
-
-const store = new Store(kinto, "items");
+import Auth from "./auth";
+import Controller from "./controller";
+import Store from "./store";
 
 
-React.render(<App store={store}/>, document.getElementById("app"));
+const events = new EventEmitter();
+const auth = new Auth(events, window.location);
+const store = new Store("items", events);
+const controller = new Controller({auth, store}, events);
+
+React.render(<App controller={controller}/>, document.getElementById("app"));

--- a/scripts/store.js
+++ b/scripts/store.js
@@ -1,49 +1,86 @@
-import { EventEmitter } from "events";
+import Kinto from "kinto";
 
 
-export class Store extends EventEmitter {
+export default class Store {
 
-  constructor(kinto, collection) {
-    super();
+  constructor(dataset, events) {
     this.state = {items: []};
-    this.collection = kinto.collection(collection);
+    this.dataset = dataset;
+    this.events = events;
+    this.collection = null;
+  }
+
+  configure(connection) {
+    try {
+      const kinto = new Kinto({
+        remote: connection.server,
+        dbPrefix: connection.user,
+        headers: connection.headers
+      });
+      this.collection = kinto.collection(this.dataset);
+    }
+    catch (e) {
+      this.onError(e);
+    }
   }
 
   onError(error) {
-    this.emit("error", error);
+    this.events.emit('store:busy', false);
+    this.events.emit("store:error", error);
+  }
+
+  onReady() {
+    this.events.emit("store:change", this.state);
+    this.events.emit('store:busy', false);
+  }
+
+  _execute(promise) {
+    this.events.emit('store:busy', true);
+    return promise
+      .then(this.onReady.bind(this))
+      .catch(this.onError.bind(this));
   }
 
   load() {
-    return this.collection.list()
-      .then(res => {
-        this.state.items = res.data;
-        this.emit("change", this.state);
-      })
-      .catch(this.onError.bind(this));
+    return this._execute(
+      this.collection.list()
+        .then(res => {
+          this.state.items = res.data;
+        }));
   }
 
   create(record) {
-    return this.collection.create(record)
-      .then(res => {
-        this.state.items.push(res.data);
-        this.emit("change", this.state);
-      })
-      .catch(this.onError.bind(this));
+    return this._execute(
+      this.collection.create(record)
+        .then(res => {
+          this.state.items.push(res.data);
+        }));
+  }
+
+  update(record) {
+    return this._execute(
+      this.collection.update(record)
+        .then(res => {
+          this.state.items = this.state.items.map(item => {
+            return item.id === record.id ? res.data : item;
+          });
+        }));
+  }
+
+  delete(record) {
+    return this._execute(
+      this.collection.delete(record.id)
+        .then(res => {
+          this.state.items = this.state.items.filter(item => {
+            return item.id !== record.id;
+          });
+        }));
   }
 
   sync() {
-    return this.collection.sync()
-      .then((res) => {
-        if (res.ok) {
-          return this.load();
-        }
-
-        // If conflicts, take remote version and sync again (recursively).
-        return Promise.all(res.conflicts.map(conflict => {
-          return this.collection.resolve(conflict, conflict.remote);
-        }))
-        .then(_ => this.sync());
-      })
+    this.events.emit('store:busy', true);
+    this.collection.sync({strategy: Kinto.syncStrategy.SERVER_WINS})
+      .then(this.load.bind(this))
       .catch(this.onError.bind(this));
   }
 }

--- a/style.css
+++ b/style.css
@@ -5,3 +5,37 @@
 .error {
   color: red;
 }
+
+li > form {
+  display: inline-block;
+}
+
+li.updated, li.created {
+  color: blue;
+}
+
+.preferences {
+    margin: 10px;
+    padding: 10px;
+    border-left: solid 1px lightgray;
+}
+
+.preferences > input {
+    display: none;
+}
+
+.preferences form {
+    display: none;
+}
+
+.preferences input:checked ~ form {
+    display: block;
+}
+
+.preferences > input ~ label::after {
+    content: '  \25b8';
+}
+
+.preferences > input:checked ~ label::after {
+    content: '  \25be';
+}

--- a/test/auth_test.js
+++ b/test/auth_test.js
@@ -1,0 +1,61 @@
+import { expect } from "chai";
+import jsdom from "jsdom";
+import { EventEmitter } from "events";
+import sinon from "sinon";
+
+import Auth from "../scripts/auth";
+
+
+describe("Auth", () => {
+
+  var auth, events, location;
+
+  beforeEach(() => {
+    location = {hash: ''};
+    events = new EventEmitter();
+    auth = new Auth(events, location);
+  });
+
+
+  describe("#configure()", () => {
+
+    it("sets server from config", () => {
+      const server = 'http://kinto-storage.org';
+      auth.configure({server});
+      expect(auth.server).to.eql(server);
+    });
+  });
+
+
+  describe("#authenticate()", () => {
+
+    it("takes username from location hash", (done) => {
+      events.on('auth:login', info => {
+        expect(info.user).to.eql('token');
+        done();
+      });
+      location.hash = '#token';
+      auth.authenticate();
+    });
+
+    it("uses default username if no hash", (done) => {
+      events.on('auth:login', info => {
+        expect(info.user).to.eql('public-demo');
+        done();
+      });
+      location.hash = '';
+      auth.authenticate();
+    });
+
+    it("provides headers and server", (done) => {
+      auth.configure({server: 'server.com'});
+
+      events.on('auth:login', info => {
+        expect(info.server).to.eql('server.com');
+        expect(info.headers.Authorization).to.eql('Basic cHVibGljLWRlbW86czNjcjN0');
+        done();
+      });
+      auth.authenticate();
+    });
+  });
+});

--- a/test/components/app_test.js
+++ b/test/components/app_test.js
@@ -1,127 +1,291 @@
+import { EventEmitter } from "events";
+import { expect } from "chai";
 import React from "react";
 import TestUtils from "react/lib/ReactTestUtils";
-import { expect } from "chai";
 import sinon from "sinon";
-import Kinto from "kinto";
 
-import App, { Form, List } from "../../scripts/components/App";
-import { Store } from "../../scripts/store";
+import App, { Form, List, Item, Preferences } from "../../scripts/components/App";
+import Controller from "../../scripts/controller";
+import Store from "../../scripts/store";
+import Auth from "../../scripts/auth";
+
 
 describe("App", () => {
 
   var sandbox;
-  var store;
+  var controller;
+  var events;
 
   beforeEach(() => {
     sandbox = sinon.sandbox.create();
-    const kinto = new Kinto();
-    store = new Store(kinto, "items");
+
+    events = new EventEmitter();
+
+    const auth = new Auth(events, {hash: ''});
+    const store = new Store('', events);
+    ["create", "delete", "load", "update", "sync"].forEach(method => {
+      sinon.stub(store, method).returns(Promise.resolve({}))
+    });
+    controller = new Controller({store, auth}, events);
   });
 
   afterEach(() => {
     sandbox.restore();
   });
 
-  describe("Component", () => {
+
+  describe("Main", () => {
 
     var rendered;
 
     beforeEach(() => {
-      sandbox.stub(store, "load").returns(Promise.resolve({}));
-      sandbox.stub(store, "sync").returns(Promise.resolve({}));
-      rendered = TestUtils.renderIntoDocument(<App store={store}/>);
+      rendered = TestUtils.renderIntoDocument(<App controller={controller}/>);
     });
 
-    it("adds item to the store on form submit", () => {
-      const node = React.findDOMNode(rendered).querySelector("input");
-      // XXX: no effect :(
-      // TestUtils.Simulate.click(node);
-      // TestUtils.Simulate.change(node, {target: {value: "Hello, world"}});
-      node.value = "Hello, world";
-      const form = React.findDOMNode(rendered).querySelector("form");
-      sandbox.stub(store.collection, "create").returns(Promise.resolve({}));
-      TestUtils.Simulate.submit(form);
-      sinon.assert.calledWithExactly(store.collection.create, {label: "Hello, world"});
+    it("triggers action start on mount", () => {
+      var callback = sinon.spy();
+      events.on('action:start', callback);
+      TestUtils.renderIntoDocument(<App controller={controller}/>);
+      sinon.assert.calledOnce(callback);
     });
 
-    it("loads items from store on mount", () => {
-      sinon.assert.calledOnce(store.load);
-    });
-
-    it("syncs store on button click", () => {
-      const node = React.findDOMNode(rendered).querySelector("div > button");
-      TestUtils.Simulate.click(node);
-      sinon.assert.calledOnce(store.sync);
-    });
-
-    it("disables button during sync", () => {
-      rendered.syncRecords();
-      let selector = ".disabled button[disabled]";
-      let node = React.findDOMNode(rendered);
-      expect(node.querySelector(selector)).to.exist;
-      store.emit("change", {});
-      expect(node.querySelector(selector)).to.not.exist;
-    });
-
-    it("renders items of store when store changes", () => {
-      store.emit("change", {items: [{id: "id", label: ":)"}]});
-      let node = React.findDOMNode(rendered);
+    it("renders items when store changes", () => {
+      events.emit("store:change", {items: [{id: "id", label: ":)"}]});
+      const node = React.findDOMNode(rendered);
       expect(node.querySelector("li").textContent).to.eql(":)");
     });
 
+    it("triggers action sync on button click", () => {
+      var callback = sinon.spy();
+      events.on('action:sync', callback);
+      const node = React.findDOMNode(rendered).querySelector("div > button");
+      TestUtils.Simulate.click(node);
+      sinon.assert.calledOnce(callback);
+    });
+
+    it("disables button while busy", () => {
+      let selector = ".disabled button[disabled]";
+      const node = React.findDOMNode(rendered);
+      events.emit("store:busy", true);
+      expect(node.querySelector(selector)).to.exist;
+      events.emit("store:busy", false);
+      expect(node.querySelector(selector)).to.not.exist;
+    });
+
     it("shows message when error happens", () => {
-      store.emit("error", new Error("Failed"));
-      let node = React.findDOMNode(rendered);
+      events.emit("store:error", new Error("Failed"));
+      const node = React.findDOMNode(rendered);
       expect(node.querySelector(".error").textContent).to.eql("Failed");
     });
 
-    it("clears error message on sync", () => {
-      store.emit("error", new Error("Failed"));
-      rendered.syncRecords();
-      let node = React.findDOMNode(rendered);
+    it("clears error message when gets busy", () => {
+      events.emit("store:error", new Error("Failed"));
+      events.emit("store:busy", true);
+      const node = React.findDOMNode(rendered);
       expect(node.querySelector(".error").textContent).to.eql("");
     });
   });
-});
 
 
-describe("List", () => {
-  it("renders without problems", () => {
-    const rendered = TestUtils.renderIntoDocument(<List/>);
-    expect(React.findDOMNode(rendered).tagName).to.equal("UL");
+  /**
+   * Since there is no way to provide a `context` to a child component
+   * during instantiation, this wrapper creates a parent component
+   * with the `controller` object in the context.
+   */
+  function wrapControllerContext(Component, controller) {
+    return class ControllerComponent extends React.Component {
+        static childContextTypes = { controller: React.PropTypes.object }
+        getChildContext() { return {controller} }
+        render() { return <Component {...this.props} />; }
+    }
+  }
+
+
+  describe("Preferences", () => {
+    var rendered;
+    const server = "https://server.org/v1";
+
+    beforeEach(() => {
+      const AppPreferences = wrapControllerContext(Preferences, controller);
+      rendered = TestUtils.renderIntoDocument(<AppPreferences server={server}/>);
+    });
+
+    it("renders server value in field", () => {
+      expect(React.findDOMNode(rendered).querySelector("form input").value).to.equal(server);
+    });
+
+    it("emits action configure when field change", () => {
+      const callback = sinon.spy();
+      controller.on("action:configure", callback);
+      const field = React.findDOMNode(rendered).querySelector("form input");
+      const newvalue = "http:///localhost:8888/v1";
+      TestUtils.Simulate.change(field, {target: {value: newvalue}});
+      sinon.assert.calledWithExactly(callback, {server: newvalue});
+    });
   });
 
-  it("renders items in list", () => {
-    const items = ["Hello", "World"];
-    const rendered = TestUtils.renderIntoDocument(<List items={items}/>);
-    expect(React.findDOMNode(rendered).querySelectorAll("li").length).to.equal(2);
+
+  describe("List", () => {
+
+    var rendered;
+    const items = [{label: "Hello"}, {label: "World"}];
+
+    beforeEach(() => {
+      const AppList = wrapControllerContext(List, controller);
+      rendered = TestUtils.renderIntoDocument(<AppList items={items}/>);
+    });
+
+    it("renders items as unordered list", () => {
+      expect(React.findDOMNode(rendered).querySelectorAll("ul > li").length).to.equal(2);
+    });
+
+    it("triggers action edit on item click", () => {
+      const callback = sinon.spy();
+      controller.on("action:edit", callback);
+      const node = React.findDOMNode(rendered);
+      TestUtils.Simulate.click(node.querySelector("li:first-child"));
+      sinon.assert.calledWithExactly(callback, 0);
+    });
+
+    it("shows item as form on action edit", () => {
+      controller.dispatch("action:edit", 1);
+      const node = React.findDOMNode(rendered);
+      expect(node.querySelector("li:last-child > form")).to.exist;
+    });
+
+    it("hides form on action update", () => {
+      controller.dispatch("action:edit", 1);
+      controller.dispatch("action:update");
+      const node = React.findDOMNode(rendered);
+      expect(node.querySelector("form")).to.not.exist;
+    });
+
+    it("hides form on action delete", () => {
+      controller.dispatch("action:edit", 1);
+      controller.dispatch("action:delete");
+      const node = React.findDOMNode(rendered);
+      expect(node.querySelector("form")).to.not.exist;
+    });
   });
-});
 
 
-describe("Form", () => {
+  describe("Item", () => {
 
-  var rendered;
+    var rendered;
 
-  beforeEach(() => {
-    rendered = TestUtils.renderIntoDocument(<Form/>);
+    describe("View", () => {
+
+      beforeEach(() => {
+        const AppItem = wrapControllerContext(Item, controller);
+        rendered = TestUtils.renderIntoDocument(<AppItem item={{label: "Value"}}/>);
+      });
+
+      it("renders label in item text", () => {
+        const node = React.findDOMNode(rendered);
+        expect(node.textContent).to.equal("Value");
+      });
+
+      it("sends action edit on click", () => {
+        var callback = sinon.spy();
+        controller.on('action:edit', callback)
+        TestUtils.Simulate.click(React.findDOMNode(rendered));
+        sinon.assert.calledOnce(callback);
+      });
+    });
+
+
+    describe("Edit", () => {
+
+      beforeEach(() => {
+        const AppItem = wrapControllerContext(Item, controller);
+        rendered = TestUtils.renderIntoDocument(<AppItem editing={true} item={{label: "Value"}}/>);
+      });
+
+      it("renders form if editing", () => {
+        const node = React.findDOMNode(rendered);
+        expect(node.querySelector("form")).to.exist;
+      });
+
+      it("sends action delete on button click", () => {
+        const callback = sinon.spy();
+        controller.on('action:delete', callback)
+        const node = React.findDOMNode(rendered).querySelector("li > button");
+        TestUtils.Simulate.click(node);
+        sinon.assert.calledOnce(callback);
+      });
+    });
   });
 
-  it("renders without problems", () => {
-    expect(React.findDOMNode(rendered).tagName).to.equal("FORM");
-  });
 
-  it("contains an input field and a submit button", () => {
-    const selector = "button, input";
-    const nodes = React.findDOMNode(rendered).querySelectorAll(selector);
-    expect(nodes.length).to.equal(2);
-  });
+  describe("Form", () => {
 
-  it("uses callback on submit", () => {
-    const callback = sinon.spy();
-    rendered = TestUtils.renderIntoDocument(<Form updateRecord={callback}/>);
-    const node = React.findDOMNode(rendered);
-    TestUtils.Simulate.submit(node);
-    expect(callback.calledWith({label: ""})).to.be.true;
+    var rendered;
+
+    describe("Create", () => {
+
+      beforeEach(() => {
+        const AppForm = wrapControllerContext(Form, controller);
+        rendered = TestUtils.renderIntoDocument(<AppForm/>);
+      });
+
+      it("has placeholder", () => {
+        const input = React.findDOMNode(rendered).querySelector("input");
+        expect(input.getAttribute('placeholder')).to.equal("Label");
+      });
+
+      it("shows add button", () => {
+        const button = React.findDOMNode(rendered).querySelector("button");
+        expect(button.textContent).to.equal("Add");
+      });
+
+      it("contains an input field and a submit button", () => {
+        const selector = "button, input";
+        const nodes = React.findDOMNode(rendered).querySelectorAll(selector);
+        expect(nodes.length).to.equal(2);
+      });
+
+      it("sends create action on submit", () => {
+        const callback = sinon.spy();
+        controller.on('action:create', callback);
+
+        const field = React.findDOMNode(rendered).querySelector("form > input");
+        const newvalue = "Hola, mundo";
+        TestUtils.Simulate.change(field, {target: {value: newvalue}});
+        TestUtils.Simulate.submit(field);
+        sinon.assert.calledWithExactly(callback, {label: newvalue});
+      });
+    });
+
+
+    describe("Update", () => {
+
+      const record = {id: "42", label: "Value"};
+
+      beforeEach(() => {
+        const AppForm = wrapControllerContext(Form, controller);
+        rendered = TestUtils.renderIntoDocument(<AppForm record={record} />);
+      });
+
+      it("shows save button", () => {
+        const button = React.findDOMNode(rendered).querySelector("button");
+        expect(button.textContent).to.equal("Save");
+      });
+
+      it("renders label in field value if editing", () => {
+        var node = React.findDOMNode(rendered);
+        expect(node.querySelector("input").value).to.equal("Value");
+      });
+
+      it("sends update action on submit", () => {
+        const callback = sinon.spy();
+        controller.on('action:update', callback);
+
+        const field = React.findDOMNode(rendered).querySelector("form > input")
+        const newvalue = "Hola, mundo";
+        TestUtils.Simulate.change(field, {target: {value: newvalue}});
+        TestUtils.Simulate.submit(field);
+        sinon.assert.calledWithExactly(callback, {id: "42", label: newvalue});
+      });
+    });
   });
 });

--- a/test/controller_test.js
+++ b/test/controller_test.js
@@ -1,0 +1,139 @@
+import { expect } from "chai";
+import { EventEmitter } from "events";
+import sinon from "sinon";
+
+import Auth from "../scripts/auth";
+import Controller from "../scripts/controller";
+import Store from "../scripts/store";
+
+
+describe("Controller", () => {
+  var controller, auth, store, events;
+
+  beforeEach(() => {
+    events = new EventEmitter();
+    auth = new Auth(events, {hash: ''});
+    store = new Store('dataset', events);
+    controller = new Controller({auth, store}, events);
+  });
+
+  describe("#on()", () => {
+    it("supports multiple comma-separated event names", () => {
+      const callback = sinon.spy();
+      controller.on('event1, event2', callback);
+      events.emit('event1');
+      events.emit('event2');
+      sinon.assert.calledTwice(callback);
+    });
+  });
+
+  describe("#dispatch()", () => {
+    it("emits event and associated data", () => {
+      const callback = sinon.spy();
+      controller.on('event', callback);
+      controller.dispatch('event', {title: 'Top'});
+      sinon.assert.calledWithExactly(callback, {title: 'Top'});
+    });
+  });
+
+
+  describe("Start", () => {
+    it("configures with default configuration", () => {
+      const callback = sinon.spy();
+      controller.on('config:change', callback);
+      window.localStorage.removeItem('config');
+      events.emit('action:start');
+      sinon.assert.calledWithExactly(callback, {server: "https://kinto.dev.mozaws.net/v1"});
+    });
+
+    it("reads from localStorage if present", () => {
+      const callback = sinon.spy();
+      controller.on('config:change', callback);
+      window.localStorage.setItem('config', '{"server":"http://kinto.com/v1"}');
+      events.emit('action:start');
+      sinon.assert.calledWithExactly(callback, {server: "http://kinto.com/v1"});
+    });
+  });
+
+
+  describe("Configuration", () => {
+    const config = {server: 'http://kinto.com/v1'};
+
+    beforeEach(() => {
+      sinon.spy(auth, 'authenticate');
+      sinon.spy(auth, 'configure');
+      events.emit('action:configure', config);
+    });
+
+    it("emits config change", () => {
+      const callback = sinon.spy();
+      controller.on('config:change', callback);
+      events.emit('action:configure', config);
+      sinon.assert.calledWithExactly(callback, config);
+    });
+
+    it("stores config in localstorage", () => {
+      expect(window.localStorage.getItem('config')).to.eql('{"server":"http://kinto.com/v1"}');
+    });
+
+    it("auth component is configured", () => {
+      sinon.assert.calledWithExactly(auth.configure, config);
+    });
+
+    it("starts authentication", () => {
+      sinon.assert.called(auth.authenticate);
+    });
+  });
+
+  describe("Login", () => {
+    const info = {server: 'http://kinto.com/v1', headers: {}, user: 'me'};
+
+    beforeEach(() => {
+      sinon.spy(store, 'configure');
+      sinon.spy(store, 'load');
+      events.emit('auth:login', info)
+    });
+
+    it("store component is configured", () => {
+      sinon.assert.calledWithExactly(store.configure, info);
+    });
+
+    it("loads store", () => {
+      sinon.assert.called(store.load);
+    });
+  });
+
+
+  describe("CRUD", () => {
+    const record = {title: "App"};
+
+    beforeEach(() => {
+      store.configure({server: 'http://kinto.com/v1', headers: {}, user: 'me'});
+      sinon.spy(store, 'create');
+      sinon.spy(store, 'update');
+      sinon.spy(store, 'delete');
+      sinon.spy(store, 'sync');
+    });
+
+    it("creates record", () => {
+      controller.dispatch("action:create", record);
+      sinon.assert.calledWithExactly(store.create, record);
+    });
+
+    it("updates record", () => {
+      const updated = Object.assign(record, {id: "1234"});
+      controller.dispatch("action:update", updated);
+      sinon.assert.calledWithExactly(store.update, updated);
+    });
+
+    it("deletes record", () => {
+      controller.dispatch("action:delete", record);
+      sinon.assert.calledWithExactly(store.delete, record);
+    });
+
+    it("syncs store", () => {
+      controller.dispatch("action:sync");
+      sinon.assert.called(store.sync);
+    });
+  });
+});


### PR DESCRIPTION
This PR could serve as a tutorial (or base branch) to add «edit in place» for the list.

This PR could remain open, regularly rebased. And developers could comment or ask questions. This would allow to keep the master boilerplate minimalistic, while providing well known use-cases.

Thoughts ?
